### PR TITLE
Ajax refactor

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,38 +1,53 @@
+function noWork() {
+    return;
+}
+
+var loading_func = noWork;
+var onError_func = noWork;
+var success_func = noWork;
+
 exports.init = function() {
-    var httpRequest;
-    var w = (typeof window === 'undefined') ? require('xmlhttprequest') : window;
+    const w = (typeof window === 'undefined') ? require('xmlhttprequest') : window;
+    var httpRequest = new w.XMLHttpRequest();
 
-    if (w.XMLHttpRequest) { // Mozilla, Safari, ...
-        httpRequest = new w.XMLHttpRequest();
-
-        if (httpRequest.overrideMimeType) {
-            httpRequest.overrideMimeType('text/xml');
-        }
-    } else if (window.ActiveXObject) { // IE
-        try {
-            httpRequest = new ActiveXObject("Msxml2.XMLHTTP");
-        } catch(e) {
-            try {
-                httpRequest = new ActiveXObject("Microsoft.XMLHTTP");
-            } catch(e) {
-                alert('ERROR: ' + e.description);
+    httpRequest.onreadystatechange = function() {
+        if (httpRequest.readyState === httpRequest.DONE) {
+            if (httpRequest.status === 200) {
+                success_func(httpRequest);
+            } else {
+                onError_func(httpRequest);
             }
+        } else {
+            loading_func();
         }
-    }
-    return httpRequest;
-}
+    };
 
-exports.setInstance = function(httpRequest, func) {
-    httpRequest.onreadystatechange = func;
-}
+    if (httpRequest.overrideMimeType) {
+        httpRequest.overrideMimeType('text/xml');
+    }
+
+    return httpRequest;
+};
+
+exports.setOnLoading = function(func) {
+    loading_func = func;
+};
+
+exports.setOnSuccess = function(func) {
+    success_func = func;
+};
+
+exports.setOnError = function(func) {
+    onError_func = func;
+};
 
 exports.get = function(httpRequest, url) {
     httpRequest.open('GET', url, true);
     httpRequest.send(null);
-}
+};
 
 exports.post = function(httpRequest, url, query) {
     httpRequest.open('POST', url, true);
     httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     httpRequest.send(query);
-}
+};

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -2,13 +2,18 @@ function noWork() {
     return;
 }
 
+var httpRequest = null;
 var loading_func = noWork;
 var onError_func = noWork;
 var success_func = noWork;
 
 exports.init = function() {
+    if (httpRequest) {
+        return;
+    }
+
     const w = (typeof window === 'undefined') ? require('xmlhttprequest') : window;
-    var httpRequest = new w.XMLHttpRequest();
+    httpRequest = new w.XMLHttpRequest();
 
     httpRequest.onreadystatechange = function() {
         if (httpRequest.readyState === httpRequest.DONE) {
@@ -25,8 +30,10 @@ exports.init = function() {
     if (httpRequest.overrideMimeType) {
         httpRequest.overrideMimeType('text/xml');
     }
+};
 
-    return httpRequest;
+exports.close = function() {
+    httpRequest = null;
 };
 
 exports.setOnLoading = function(func) {
@@ -41,12 +48,12 @@ exports.setOnError = function(func) {
     onError_func = func;
 };
 
-exports.get = function(httpRequest, url) {
+exports.get = function(url) {
     httpRequest.open('GET', url, true);
     httpRequest.send(null);
 };
 
-exports.post = function(httpRequest, url, query) {
+exports.post = function(url, query) {
     httpRequest.open('POST', url, true);
     httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     httpRequest.send(query);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -8,9 +8,7 @@ var onError_func = noWork;
 var success_func = noWork;
 
 exports.init = function() {
-    if (httpRequest) {
-        return;
-    }
+    this.close();
 
     const w = (typeof window === 'undefined') ? require('xmlhttprequest') : window;
     httpRequest = new w.XMLHttpRequest();
@@ -33,7 +31,9 @@ exports.init = function() {
 };
 
 exports.close = function() {
-    httpRequest = null;
+    if (httpRequest) {
+        httpRequest = null;
+    }
 };
 
 exports.setOnLoading = function(func) {

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -1,5 +1,5 @@
 describe('ajax', () => {
-  let ajax, httpRequest;
+  let ajax;
   let server = null;
   let timeout_id = NaN;
   const access_test_url = "http://127.0.0.1:13370/";
@@ -25,7 +25,7 @@ describe('ajax', () => {
 
   beforeEach(() => {
     ajax = require('../src/ajax');
-    httpRequest = ajax.init();
+    ajax.init();
     startHttpServer();
   })
 
@@ -40,7 +40,7 @@ describe('ajax', () => {
 
       ajax.setOnSuccess(fetchData);
       ajax.setOnError(fetchData);
-      ajax.get(httpRequest, access_test_url);
+      ajax.get(access_test_url);
     })
   })
 })

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -1,12 +1,22 @@
 describe('ajax', () => {
-  let ajax, httpRequest, server;
+  let ajax, httpRequest;
+  let server = null;
+  let timeout_id = NaN;
   const access_test_url = "http://127.0.0.1:13370/";
   const response_data   = '200 OK';
+
+  function stopHttpServer() {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  }
 
   function startHttpServer() {
     const response_header = {'Content-Type': 'text/plain'};
 
     var http = require('http');
+    timeout_id = setTimeout(stopHttpServer, 5000);
     server = http.createServer(function (req, res) {
       res.writeHead(200, response_header);
       res.end(response_data);
@@ -21,23 +31,15 @@ describe('ajax', () => {
 
   describe('get()', () => {
     test('expect 200 OK', done => {
-      function fetchData() {
-        var ret = new Object();
-        if (httpRequest.readyState == 0 || httpRequest.readyState == 1 || httpRequest.readyState == 2) {
-          //document.getElementById('mapLoading').innerHTML = "読み込み中...";
-        } else if (httpRequest.readyState == 4) {
-          if (httpRequest.status == 200) {
-            ret.data = httpRequest.responseText;
-          }
-          ret.status = httpRequest.status;
-
-          expect(ret.status).toBe(200);
-          server.close();
-          done();
-        }
+      function fetchData(xhr) {
+        expect(xhr.status).toBe(200);
+        clearTimeout(timeout_id);
+        stopHttpServer();
+        done();
       }
 
-      ajax.setInstance(httpRequest, fetchData);
+      ajax.setOnSuccess(fetchData);
+      ajax.setOnError(fetchData);
       ajax.get(httpRequest, access_test_url);
     })
   })


### PR DESCRIPTION
* 引数から httpRequest を無くした (複数のリクエストを同時に投げることはできなくなる制限)
* 状態毎に実行する関数をセットするようにして、アクセスの状態分岐をコードに書くことをやめた
    * setOnLoading: 読込み中に実行する処理
    * setOnSuccess: 成功したときに実行する処理
    * setOnError: エラーになった時に実行する処理