### PR TITLE
ajaxでopenしてからsetRequestHeaderするように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+coverage/
 node_modules/

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var c = new Object();
-c.datetime = require('./src/datetime');
-c.ajax     = require('./src/ajax');
-c.value    = require('./src/value');
-module.exports = c;
+module.exports.datetime = require('./src/datetime');
+module.exports.ajax     = require('./src/ajax');
+module.exports.value    = require('./src/value');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "JavaScript library for npm package",
   "license": "MIT",
   "main": "index.js",

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -26,7 +26,6 @@ function stateChangedWork() {
 }
 
 function setHeaders() {
-request_headers
     for (var i in request_headers) {
         if (request_headers.hasOwnProperty(i)) {
             httpRequest.setRequestHeader(i, request_headers[i]);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -76,6 +76,8 @@ exports.get = function(url) {
 exports.post = function(url, query) {
     httpRequest.open('POST', url, true);
     setHeaders();
-    httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    if (!request_headers['Content-Type']) {
+        httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    }
     httpRequest.send(query);
 };

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -3,6 +3,7 @@ function noWork() {
 }
 
 var httpRequest = null;
+var request_headers = new Object();
 var loading_func = noWork;
 var onError_func = noWork;
 var success_func = noWork;
@@ -23,6 +24,15 @@ function stateChangedWork() {
         loading_func();
     }
 }
+
+function setHeaders() {
+request_headers
+    for (var i in request_headers) {
+        if (request_headers.hasOwnProperty(i)) {
+            httpRequest.setRequestHeader(i, request_headers[i]);
+        }
+    }
+};
 
 exports.init = function() {
     this.close();
@@ -53,17 +63,19 @@ exports.setOnError = function(func) {
     onError_func = func;
 };
 
-exports.setRequestHeader = function(header, value) {
-    httpRequest.setRequestHeader(header, value);
+exports.setRequestHeader = function(headers) {
+    request_headers = headers;
 };
 
 exports.get = function(url) {
     httpRequest.open('GET', url, true);
+    setHeaders();
     httpRequest.send(null);
 };
 
 exports.post = function(url, query) {
     httpRequest.open('POST', url, true);
+    setHeaders();
     httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     httpRequest.send(query);
 };

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -4,8 +4,11 @@ describe('ajax', () => {
   let timeout_id = NaN;
   const access_test_url = "http://127.0.0.1:13370/";
   const response_data   = '200 OK';
+  var received_request;
 
   function stopHttpServer() {
+    clearTimeout(timeout_id);  // 妥当ではないIDを渡しても効果無く例外は発生しない
+
     if (server) {
       server.close();
       server = null;
@@ -18,22 +21,24 @@ describe('ajax', () => {
     var http = require('http');
     timeout_id = setTimeout(stopHttpServer, 5000);
     server = http.createServer(function (req, res) {
+      received_request = req;
       res.writeHead(200, response_header);
       res.end(response_data);
     }).listen(13370, '127.0.0.1');
   }
 
   beforeEach(() => {
+    received_request = new Object();
     ajax = require('../src/ajax');
     ajax.init();
     startHttpServer();
-  })
+  });
 
   describe('get()', () => {
     test('expect 200 OK', done => {
       function fetchData(xhr) {
+        expect(received_request.method.toUpperCase()).toBe('GET');
         expect(xhr.status).toBe(200);
-        clearTimeout(timeout_id);
         stopHttpServer();
         done();
       }
@@ -41,6 +46,58 @@ describe('ajax', () => {
       ajax.setOnSuccess(fetchData);
       ajax.setOnError(fetchData);
       ajax.get(access_test_url);
-    })
-  })
+    });
+    test('set customized header', done => {
+      function fetchData(xhr) {
+        expect(received_request.method.toUpperCase()).toBe('GET');
+        expect(received_request.headers['x-customized-value']).toBe('check_ok');
+        expect(xhr.status).toBe(200);
+        stopHttpServer();
+        done();
+      }
+
+      ajax.setRequestHeader({
+        "x-customized-value": "check_ok"
+      });
+
+      ajax.setOnSuccess(fetchData);
+      ajax.setOnError(fetchData);
+      ajax.get(access_test_url);
+    });
+  });
+
+  describe('post()', () => {
+    test('expect 200 OK', done => {
+      function fetchData(xhr) {
+        expect(received_request.method.toUpperCase()).toBe('POST');
+        expect(received_request.headers['content-type']).toBe('application/x-www-form-urlencoded');
+        expect(xhr.status).toBe(200);
+        stopHttpServer();
+        done();
+      }
+
+      ajax.setOnSuccess(fetchData);
+      ajax.setOnError(fetchData);
+      ajax.post(access_test_url, null);
+    });
+    test('set customized header', done => {
+      function fetchData(xhr) {
+        expect(received_request.method.toUpperCase()).toBe('POST');
+        expect(received_request.headers['content-type']).toBe('text/plain');
+        expect(received_request.headers['x-customized-value']).toBe('check_ok');
+        expect(xhr.status).toBe(200);
+        stopHttpServer();
+        done();
+      }
+
+      ajax.setRequestHeader({
+        "Content-Type": "text/plain",
+        "x-customized-value": "check_ok"
+      });
+
+      ajax.setOnSuccess(fetchData);
+      ajax.setOnError(fetchData);
+      ajax.post(access_test_url, null);
+    });
+  });
 })


### PR DESCRIPTION
openする前にヘッダをセットすると `setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.` のエラーが出て失敗するため、セットしたい値を一旦オブジェクトにしまうように変更した