### PR TITLE
Coverage集計の追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+git:
+  depth: 5
 language: node_js
 node_js:
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ git:
 language: node_js
 node_js:
   - "node"
+script:
+  - npm run test:cc-report

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/suzutsuki0220/jsUtils.svg?branch=master)](https://travis-ci.org/suzutsuki0220/jsUtils)
 [![Maintainability](https://api.codeclimate.com/v1/badges/c242c181d89860bf058e/maintainability)](https://codeclimate.com/github/suzutsuki0220/jsUtils/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c242c181d89860bf058e/test_coverage)](https://codeclimate.com/github/suzutsuki0220/jsUtils/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/suzutsuki0220/jsUtils.svg)](https://github.com/suzutsuki0220/jsUtils/blob/master/LICENSE)
 
 # jsUtils

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:cc-report": "CC_TEST_REPORTER_ID=77c63b9255e266fffca0db0ebeb9d71ba089d0f9c28db73e8e3071ec3f8e8574 GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$') jest --coverage && ./test-reporter-latest-linux-amd64 after-build -t lcov --exit-code $?"
+    "test:cc-report": "jest --coverage && CC_TEST_REPORTER_ID=77c63b9255e266fffca0db0ebeb9d71ba089d0f9c28db73e8e3071ec3f8e8574 GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$') ./test-reporter-latest-linux-amd64 after-build -t lcov --exit-code $?"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:cc-report": "CC_TEST_REPORTER_ID=77c63b9255e266fffca0db0ebeb9d71ba089d0f9c28db73e8e3071ec3f8e8574 GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$') jest --coverage && ./test-reporter-latest-linux-amd64 after-build -t lcov --exit-code $?"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* `npm run test:cc-report` で codeclimate に結果を送るようにした
* Travis CI の設定変更
* readmeに coverage のバッジを追加