### PR TITLE
CodeClimate の test-reporter を毎回ダウンロードするように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 # editor temporary file
 *.swp
 *~
+
+cc-test-reporter

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:cc-report": "jest --coverage && CC_TEST_REPORTER_ID=77c63b9255e266fffca0db0ebeb9d71ba089d0f9c28db73e8e3071ec3f8e8574 GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$') ./test-reporter-latest-linux-amd64 after-build -t lcov --exit-code $?"
+    "test:cc-report": "run-s test:coverage test:get-reporter test:upload-report",
+    "test:get-reporter": "if [ ! -x ./cc-test-reporter ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter; fi",
+    "test:upload-report": "CC_TEST_REPORTER_ID=77c63b9255e266fffca0db0ebeb9d71ba089d0f9c28db73e8e3071ec3f8e8574 GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$') ./cc-test-reporter after-build -t lcov --exit-code $?"
   },
   "repository": {
     "type": "git",
@@ -18,6 +20,7 @@
   },
   "devDependencies": {
     "jest": "^23.6.0",
+    "npm-run-all": "^4.1.5",
     "xmlhttprequest": "^1.8.0"
   },
   "jest": {


### PR DESCRIPTION
cc-test-reporter はサイズが12MB程ある。jsUtilsがライブラリとして `node_modules` に含まれてしまうとそれなりに大きくなってしまうので、外したいことからテストスクリプトの中で取得して実行するようにしたい