### PR TITLE
Tag打ちのmasterブランチチェックをtravis内で行う

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   include:
     - stage: release
+      if: branch = master
       node_js: "node"
       script:
         - ./post-commit.sh || git push https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git --tags

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-utils",
-  "version": "0.1.02",
+  "version": "0.1.03",
   "description": "JavaScript library for npm package",
   "license": "MIT",
   "main": "index.js",

--- a/post-commit.sh
+++ b/post-commit.sh
@@ -18,18 +18,9 @@ function is_exist_tag() {
     echo "false"
 }
 
-function is_master() {
-    git branch --list |grep "\* master" 2>&1 > /dev/null
-    if [ $? -eq 0 ]; then
-        echo "true"
-    else
-        echo "false"
-    fi
-}
-
 if [ "$version" != "" ]; then
     new_tag="v${version}"
-    if [ `is_master` == "true" -a `is_exist_tag ${new_tag}` == "false" ]; then
+    if [ `is_exist_tag ${new_tag}` == "false" ]; then
         create_tag ${new_tag}
         exit 1
     fi


### PR DESCRIPTION
travis CI では、特定コミットにチェックアウトするためにmasterブランチにならない

```
$ git checkout -qf b74d42732997986ff9d9bd9979a93ca99251a210
```

ブランチはtravis.ymlで確認するように変更した